### PR TITLE
fix: add HTTPS support for getNetworkDownloadSpeed

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,7 @@
 const http = require('http');
+const https = require('https');
+const URL = require('url').URL;
+
 const chars =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*()_+`-=[]{}|;':,./<>?";
 
@@ -9,11 +12,17 @@ class NetworkSpeedCheck {
    * @param {Number} fileSizeInBytes {Required} The size (in bytes) of the file to be downloaded
    * @returns {Object}
    */
+
+  _protocol (url) {
+    var u = new URL(url)
+    return u.protocol === 'http:' ? http : https
+  }
   checkDownloadSpeed(baseUrl, fileSizeInBytes) {
     this.validateDownloadSpeedParams(baseUrl, fileSizeInBytes)
     let startTime;
+    let protocol = this._protocol(baseUrl)
     return new Promise((resolve, _) => {
-      return http.get(baseUrl, response => {
+      return protocol.get(baseUrl, response => {
         response.once('data', () => {
           startTime = new Date().getTime();
         });

--- a/test/test.js
+++ b/test/test.js
@@ -4,8 +4,29 @@ let NetworkSpeed = require('../app');
 let expect = require('chai').expect;
 const testNetworkSpeed = new NetworkSpeed();
 
-describe('Network Download Speed', () => {
-  it('it should recieve a key value pair for bps, kbps and mbps', done => {
+describe('HTTPS Network Download Speed', () => {
+  it('HTTPS it should recieve a key value pair for bps, kbps and mbps', done => {
+    async function getNetworkDownloadSpeed() {
+      const baseUrl = 'https://eu.httpbin.org/stream-bytes/50000000';
+      const fileSize = 500000;
+      try {
+        const speed = await testNetworkSpeed.checkDownloadSpeed(
+          baseUrl,
+          fileSize,
+        );
+        expect(speed).to.include.all.keys('bps', 'kbps', 'mbps');
+        done();
+      } catch (err)  {
+        console.error(err)
+        done(err)
+      }
+    }
+    getNetworkDownloadSpeed()
+  });
+});
+
+describe('HTTP Network Download Speed', () => {
+  it('HTTP it should recieve a key value pair for bps, kbps and mbps', done => {
     getNetworkDownloadSpeed();
     async function getNetworkDownloadSpeed() {
       const baseUrl = 'http://eu.httpbin.org/stream-bytes/50000000';


### PR DESCRIPTION
fixes #72 