### PR TITLE
Bugfix: Pending Promise on Req Failure

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,8 +47,8 @@ class NetworkSpeedCheck {
     let startTime;
     const defaultData = this.generateTestData(fileSizeInBytes / 1000);
     const data = JSON.stringify({ defaultData });
-    return new Promise((resolve, _) => {
-      var req = http.request(options, res => {
+    return new Promise((resolve, reject) => {
+      let req = http.request(options, res => {
         res.setEncoding("utf8");
         res.on('data', () => {});
         res.on("end", () => {
@@ -63,13 +63,11 @@ class NetworkSpeedCheck {
       });
       startTime = new Date().getTime();
       req.on('error', error => {
-        console.error(error);
+        reject(error)
       });
       req.write(data)
       req.end()
-    }).catch(error => {
-      console.log(error);
-    });
+    })
   }
 
   validateDownloadSpeedParams(baseUrl, fileSizeInBytes) {


### PR DESCRIPTION
* Fixed an issue where not having an internet connection and trying to perform a speed test would result in the promise never resolving. Properly rejecting on error.

* Changed var to let to be the same throughout the library.
* Removed Console Log Statement as the error is now properly bubbled up.
* Renamed _ to reject as this is typically what you see when dealing with promises. _ gives no context and is unclear.
* Removed 

```
.catch(error => {
      console.log(error);	
    });
```

This code will never execute as you can't catch a new Promise.